### PR TITLE
Suggested Transfers feature 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,32 @@
-import { Box, Stack } from "@mui/material"
-import AppBar from "@mui/material/AppBar"
-import Button from "@mui/material/Button"
-import CssBaseline from "@mui/material/CssBaseline"
-import { ThemeProvider } from "@mui/material/styles"
-import Toolbar from "@mui/material/Toolbar"
-import { useEffect } from "react"
-import { HashRouter, Link, Route, Routes } from "react-router"
-import { pickOptimalFPLTeamAdvanced } from "./app/algo"
-import { useSettingsStore } from "./app/settings"
-import theme from "./app/theme"
-import PageTitle from "./components/PageTitle"
-import SpaceBetween from "./components/SpaceBetween"
-import Charts from "./modules/Charts"
-import FDRPage from "./modules/FDR"
-import GenerateLineup from "./modules/GenerateLineup"
-import Home from "./modules/Home"
-import Players from "./modules/Players"
-import PlayersCompare from "./modules/player-compare/PlayersCompare"
-import SquadRatingPage from "./modules/squad-rating/SquadRatingPage"
-import Support from "./modules/Support"
-import TuneAlgo from "./modules/tune-algo"
+import { Box, Stack } from "@mui/material";
+import AppBar from "@mui/material/AppBar";
+import Button from "@mui/material/Button";
+import CssBaseline from "@mui/material/CssBaseline";
+import { ThemeProvider } from "@mui/material/styles";
+import Toolbar from "@mui/material/Toolbar";
+import { useEffect } from "react";
+import { HashRouter, Link, Route, Routes } from "react-router";
+import { pickOptimalFPLTeamAdvanced } from "./app/algo";
+import { useSettingsStore } from "./app/settings";
+import theme from "./app/theme";
+import PageTitle from "./components/PageTitle";
+import SpaceBetween from "./components/SpaceBetween";
+import Charts from "./modules/Charts";
+import FDRPage from "./modules/FDR";
+import GenerateLineup from "./modules/GenerateLineup";
+import Home from "./modules/Home";
+import Players from "./modules/Players";
+import SuggestedTransfersPage from "./modules/SuggestedTransfers";
+import PlayersCompare from "./modules/player-compare/PlayersCompare";
+import SquadRatingPage from "./modules/squad-rating/SquadRatingPage";
+import Support from "./modules/Support";
+import TuneAlgo from "./modules/tune-algo";
 
 function App() {
-  const { setSortedPlayers, snapshot } = useSettingsStore()
+  const { setSortedPlayers, snapshot } = useSettingsStore();
   useEffect(() => {
-    if (snapshot) setSortedPlayers(pickOptimalFPLTeamAdvanced(snapshot))
-  }, [])
+    if (snapshot) setSortedPlayers(pickOptimalFPLTeamAdvanced(snapshot));
+  }, []);
 
   return (
     <>
@@ -62,6 +63,13 @@ function App() {
                   <Button color="inherit" component={Link} to="/squad-rating">
                     Squad Rating
                   </Button>
+                  <Button
+                    color="inherit"
+                    component={Link}
+                    to="/suggested-transfers"
+                  >
+                    Suggested Transfers
+                  </Button>
                   <Button color="inherit" component={Link} to="/charts">
                     Charts
                   </Button>
@@ -71,14 +79,16 @@ function App() {
                   <Button
                     color="inherit"
                     component={Link}
-                    to="/weight-settings">
+                    to="/weight-settings"
+                  >
                     Weight Settings
                   </Button>
                   <Button
                     color="secondary"
                     component={Link}
                     to="/support"
-                    variant="contained">
+                    variant="contained"
+                  >
                     Support
                   </Button>
                 </Stack>
@@ -92,6 +102,10 @@ function App() {
               <Route path="/generate-lineup" element={<GenerateLineup />} />
               <Route path="/compare" element={<PlayersCompare />} />
               <Route path="/squad-rating" element={<SquadRatingPage />} />
+              <Route
+                path="/suggested-transfers"
+                element={<SuggestedTransfersPage />}
+              />
               <Route path="/charts" element={<Charts />} />
               <Route path="/fdr" element={<FDRPage />} />
               <Route path="/weight-settings" element={<TuneAlgo />} />
@@ -101,7 +115,7 @@ function App() {
         </HashRouter>
       </ThemeProvider>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/app/transfers.ts
+++ b/src/app/transfers.ts
@@ -1,0 +1,145 @@
+import type { IOptimalTeamPlayer, Position } from "../lib/types";
+import { POSITION_LIMITS, TEAM_LIMIT } from "./settings";
+
+export interface TransferSuggestion {
+  out: IOptimalTeamPlayer;
+  in: IOptimalTeamPlayer;
+  deltaScore: number;
+  deltaCost: number;
+}
+
+export interface SuggestTransfersArgs {
+  squad: IOptimalTeamPlayer[];
+  candidates: IOptimalTeamPlayer[];
+  bankNowCost: number;
+  freeTransfers: number;
+}
+
+export interface SuggestTransfersResult {
+  suggestions: TransferSuggestion[];
+  newSquad: IOptimalTeamPlayer[];
+  usedBank: number;
+  hits: number;
+  totalDeltaScore: number;
+  initialScore: number;
+  finalScore: number;
+}
+
+function calculateTeamScore(squad: IOptimalTeamPlayer[]): number {
+  return squad.reduce((acc, p) => acc + p.score, 0);
+}
+
+function buildTeamCountMap(
+  players: IOptimalTeamPlayer[]
+): Record<number, number> {
+  const map: Record<number, number> = {};
+  for (const p of players) map[p.teamId] = (map[p.teamId] ?? 0) + 1;
+  return map;
+}
+
+function buildPositionCountMap(
+  players: IOptimalTeamPlayer[]
+): Record<Position, number> {
+  const map: Record<Position, number> = { GK: 0, DEF: 0, MID: 0, FWD: 0 };
+  for (const p of players) map[p.position as Position] += 1;
+  return map;
+}
+
+function withinTeamLimit(
+  teamCount: Record<number, number>,
+  teamId: number
+): boolean {
+  return (teamCount[teamId] ?? 0) <= TEAM_LIMIT;
+}
+
+export function suggestTransfers(
+  args: SuggestTransfersArgs
+): SuggestTransfersResult {
+  const { squad, candidates, bankNowCost, freeTransfers } = args;
+
+  const initialScore = calculateTeamScore(squad);
+  const idsInSquad = new Set(squad.map((p) => p.element.id));
+  let availableCandidates = candidates.filter(
+    (p) => !idsInSquad.has(p.element.id)
+  );
+
+  let bank = bankNowCost;
+  let currentSquad = [...squad];
+  let teamCount = buildTeamCountMap(currentSquad);
+  let positionCount = buildPositionCountMap(currentSquad);
+
+  const suggestions: TransferSuggestion[] = [];
+
+  const maxTransfers = Math.max(0, Math.min(2, Math.floor(freeTransfers)));
+
+  for (let t = 0; t < maxTransfers; t++) {
+    let best: TransferSuggestion | null = null;
+
+    for (const out of currentSquad) {
+      const pos = out.position as Position;
+
+      for (const incoming of availableCandidates) {
+        if ((incoming.position as Position) !== pos) continue;
+
+        // Avoid duplicates
+        if (currentSquad.some((p) => p.element.id === incoming.element.id))
+          continue;
+
+        // Same-position swap preserves position counts; no extra check needed
+
+        // Team limit after swap
+        const nextTeamCount = { ...teamCount };
+        nextTeamCount[out.teamId] = (nextTeamCount[out.teamId] ?? 0) - 1;
+        nextTeamCount[incoming.teamId] =
+          (nextTeamCount[incoming.teamId] ?? 0) + 1;
+        if (!withinTeamLimit(nextTeamCount, incoming.teamId)) continue;
+
+        const deltaCost =
+          (incoming.element.now_cost ?? 0) - (out.element.now_cost ?? 0);
+        if (deltaCost > bank) continue;
+
+        const deltaScore = incoming.score - out.score;
+
+        if (
+          !best ||
+          deltaScore > best.deltaScore ||
+          (deltaScore === best.deltaScore && deltaCost < best.deltaCost)
+        ) {
+          best = { out, in: incoming, deltaScore, deltaCost };
+        }
+      }
+    }
+
+    if (!best || best.deltaScore <= 0) break;
+
+    // Apply best transfer
+    currentSquad = currentSquad.map((p) =>
+      p.element.id === best!.out.element.id ? best!.in : p
+    );
+    bank -= best.deltaCost;
+    teamCount[best.out.teamId] = (teamCount[best.out.teamId] ?? 0) - 1;
+    teamCount[best.in.teamId] = (teamCount[best.in.teamId] ?? 0) + 1;
+    // positionCount unchanged (same-position swap)
+
+    suggestions.push(best);
+    availableCandidates = availableCandidates.filter(
+      (p) => p.element.id !== best!.in.element.id
+    );
+  }
+
+  const finalScore = calculateTeamScore(currentSquad);
+  const totalDeltaScore = finalScore - initialScore;
+
+  return {
+    suggestions,
+    newSquad: currentSquad,
+    usedBank: bankNowCost - bank,
+    hits: Math.max(
+      0,
+      suggestions.length - Math.max(0, Math.floor(freeTransfers))
+    ),
+    totalDeltaScore,
+    initialScore,
+    finalScore,
+  };
+}

--- a/src/modules/Home.tsx
+++ b/src/modules/Home.tsx
@@ -1,16 +1,16 @@
-import type { SxProps } from "@mui/material"
-import Box from "@mui/material/Box"
-import Card from "@mui/material/Card"
-import CardActionArea from "@mui/material/CardActionArea"
-import CardContent from "@mui/material/CardContent"
-import Chip from "@mui/material/Chip"
-import Container from "@mui/material/Container"
-import type { GridProps } from "@mui/material/Grid"
-import Grid from "@mui/material/Grid"
-import Typography from "@mui/material/Typography"
-import { Link as RouterLink } from "react-router-dom"
+import type { SxProps } from "@mui/material";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import CardContent from "@mui/material/CardContent";
+import Chip from "@mui/material/Chip";
+import Container from "@mui/material/Container";
+import type { GridProps } from "@mui/material/Grid";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import { Link as RouterLink } from "react-router-dom";
 
-type Feature = (typeof FEATURES)[number]
+type Feature = (typeof FEATURES)[number];
 
 const ROUTES = {
   players: "/players",
@@ -19,10 +19,11 @@ const ROUTES = {
   rating: "/squad-rating",
   fdr: "/fdr",
   charts: "/charts",
+  suggestedTransfers: "/suggested-transfers",
   weightSettings: "/weight-settings",
   rules: "/rules",
   support: "/support",
-} as const
+} as const;
 
 const FEATURES = [
   {
@@ -69,13 +70,20 @@ const FEATURES = [
   //   badge: "Beta",
   // },
   {
+    key: "suggested-transfers",
+    title: "Suggested Transfers",
+    description: "Pick your squad and get optimal swap suggestions.",
+    route: ROUTES.suggestedTransfers,
+    badge: "New",
+  },
+  {
     key: "weight-settings",
     title: "Weight Settings",
     description: "Customize algorithm weights for player evaluation.",
     route: ROUTES.weightSettings,
     badge: "Advanced",
   },
-] as const
+] as const;
 
 function Home() {
   const cardSx: SxProps = {
@@ -91,13 +99,13 @@ function Home() {
       boxShadow: 6,
       borderColor: (theme: any) => theme.palette.primary.light,
     },
-  } as const
+  } as const;
 
   const actionSx = {
     display: "flex",
     alignItems: "stretch",
     height: "100%",
-  } as const
+  } as const;
 
   const contentSx = {
     display: "flex",
@@ -105,14 +113,14 @@ function Home() {
     gap: 1,
     height: "100%",
     p: 3,
-  } as const
+  } as const;
 
   const headerRowSx = {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
     mb: 1,
-  } as const
+  } as const;
 
   return (
     <Container maxWidth="lg">
@@ -121,7 +129,8 @@ function Home() {
           variant="h3"
           component="h1"
           gutterBottom
-          sx={{ fontWeight: 700 }}>
+          sx={{ fontWeight: 700 }}
+        >
           Fantasy Tools
         </Typography>
         <Typography variant="subtitle1" color="text.secondary" gutterBottom>
@@ -139,12 +148,14 @@ function Home() {
               xs: 12,
               sm: 6,
               md: 4,
-            } as GridProps)}>
+            } as GridProps)}
+          >
             <Card elevation={0} sx={cardSx}>
               <CardActionArea
                 component={RouterLink}
                 to={f.route}
-                sx={{ ...actionSx, width: "100%" }}>
+                sx={{ ...actionSx, width: "100%" }}
+              >
                 <CardContent sx={{ ...contentSx, width: "100%" }}>
                   <Box sx={headerRowSx}>
                     <Typography variant="h6" sx={{ fontWeight: 600 }}>
@@ -161,7 +172,8 @@ function Home() {
                   <Typography
                     variant="body2"
                     color="text.secondary"
-                    sx={{ flexGrow: 1 }}>
+                    sx={{ flexGrow: 1 }}
+                  >
                     {f.description}
                   </Typography>
 
@@ -172,7 +184,8 @@ function Home() {
                       alignItems: "center",
                       gap: 1,
                       pt: 1,
-                    }}>
+                    }}
+                  >
                     <Typography variant="button" color="primary">
                       Open
                     </Typography>
@@ -186,7 +199,7 @@ function Home() {
 
       <Box sx={{ py: 6 }} />
     </Container>
-  )
+  );
 }
 
-export default Home
+export default Home;

--- a/src/modules/SuggestedTransfers.tsx
+++ b/src/modules/SuggestedTransfers.tsx
@@ -1,0 +1,314 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  TextField,
+  Typography,
+  Grid,
+} from "@mui/material";
+import { useMemo, useState } from "react";
+import PageTitle from "../components/PageTitle";
+import { useSettingsStore } from "../app/settings";
+import type { IOptimalTeamPlayer } from "../lib/types";
+import {
+  suggestTransfers,
+  type SuggestTransfersResult,
+} from "../app/transfers";
+import {
+  usePlayerSelector,
+  useSearchBase,
+  priceFmt,
+} from "../hooks/usePlayerSelector";
+
+function PlayerRow({
+  p,
+  onClick,
+  selected,
+  teamName,
+  teamShort,
+}: {
+  p: IOptimalTeamPlayer;
+  onClick: () => void;
+  selected: boolean;
+  teamName: string;
+  teamShort: string;
+}) {
+  return (
+    <Button
+      onClick={onClick}
+      variant={selected ? "contained" : "text"}
+      color={selected ? "primary" : "inherit"}
+      sx={{
+        justifyContent: "space-between",
+        textTransform: "none",
+        px: 1.5,
+        py: 1,
+        borderRadius: 1,
+      }}
+    >
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        sx={{ overflow: "hidden" }}
+      >
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {p.element.web_name}
+        </Typography>
+        <Chip size="small" label={p.position} />
+        <Chip size="small" variant="outlined" label={teamShort || teamName} />
+        <Typography variant="caption" color="text.secondary">
+          {teamName}
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Typography variant="caption">Score {p.score.toFixed(1)}</Typography>
+        <Chip size="small" label={`$${priceFmt(p.element.now_cost)}`} />
+      </Stack>
+    </Button>
+  );
+}
+
+function SelectedChip({
+  p,
+  onRemove,
+  teamName,
+  teamShort,
+}: {
+  p: IOptimalTeamPlayer;
+  onRemove: () => void;
+  teamName: string;
+  teamShort: string;
+}) {
+  return (
+    <Chip
+      label={`${p.element.web_name} (${p.position}) $${priceFmt(
+        p.element.now_cost
+      )} – ${teamShort || teamName}`}
+      onDelete={onRemove}
+      color="primary"
+      variant="outlined"
+      sx={{ mr: 1, mb: 1 }}
+    />
+  );
+}
+
+function SuggestedTransfersPage() {
+  const sortedPlayers = useSettingsStore((s) => s.sortedPlayers);
+  const {
+    teamsById,
+    selectedPlayers,
+    togglePlayer,
+    removePlayer,
+    selectedIds,
+    max,
+  } = usePlayerSelector({ players: sortedPlayers });
+
+  const { q, setQ, result } = useSearchBase(sortedPlayers);
+  const filtered = useMemo(() => result.slice(0, 200), [result]);
+
+  const [bankInput, setBankInput] = useState<string>("0.0");
+  const [freeTransfers, setFreeTransfers] = useState<string>("1");
+  const [calc, setCalc] = useState<SuggestTransfersResult | null>(null);
+
+  const totalSelectedCost = useMemo(
+    () =>
+      selectedPlayers.reduce((acc, p) => acc + (p.element.now_cost ?? 0), 0) /
+      10,
+    [selectedPlayers]
+  );
+  const totalSelectedScore = useMemo(
+    () => selectedPlayers.reduce((acc, p) => acc + p.score, 0),
+    [selectedPlayers]
+  );
+
+  const handleSuggest = () => {
+    const bankNowCost = Math.max(0, Math.round((Number(bankInput) || 0) * 10));
+    const ft = Math.max(0, Math.floor(Number(freeTransfers) || 0));
+    const res = suggestTransfers({
+      squad: selectedPlayers,
+      candidates: sortedPlayers,
+      bankNowCost,
+      freeTransfers: ft,
+    });
+    setCalc(res);
+  };
+
+  return (
+    <Box>
+      <PageTitle>Suggested Transfers</PageTitle>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Suggested Transfers
+      </Typography>
+
+      <Grid container>
+        <Grid size={7} sx={{ pr: 2 }}>
+          <Card variant="outlined">
+            <CardContent>
+              <Stack
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                sx={{ mb: 2 }}
+              >
+                <TextField
+                  label="Search"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  size="small"
+                />
+                <Typography variant="body2" color="text.secondary">
+                  {selectedIds.length}/{max} selected
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Cost ${totalSelectedCost.toFixed(1)} | Score{" "}
+                  {totalSelectedScore.toFixed(1)}
+                </Typography>
+              </Stack>
+
+              <Stack spacing={1} sx={{ maxHeight: 400, overflowY: "auto" }}>
+                {filtered.map((p) => {
+                  const t = teamsById.get(p.element.team);
+                  return (
+                    <PlayerRow
+                      key={p.element.id}
+                      p={p}
+                      onClick={() => togglePlayer(p.element.id)}
+                      selected={selectedIds.includes(p.element.id)}
+                      teamName={t?.name ?? ""}
+                      teamShort={t?.short_name ?? ""}
+                    />
+                  );
+                })}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={5} sx={{ pl: 2 }}>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Selected Squad
+              </Typography>
+              <Box>
+                {selectedPlayers.map((p) => {
+                  const t = teamsById.get(p.element.team);
+                  return (
+                    <SelectedChip
+                      key={p.element.id}
+                      p={p}
+                      onRemove={() => removePlayer(p.element.id)}
+                      teamName={t?.name ?? ""}
+                      teamShort={t?.short_name ?? ""}
+                    />
+                  );
+                })}
+              </Box>
+            </CardContent>
+          </Card>
+
+          <Card variant="outlined">
+            <CardContent>
+              <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+                <TextField
+                  label="Bank (m)"
+                  value={bankInput}
+                  onChange={(e) => setBankInput(e.target.value)}
+                  size="small"
+                  inputProps={{ inputMode: "decimal" }}
+                />
+                <TextField
+                  label="Free Transfers"
+                  value={freeTransfers}
+                  onChange={(e) => setFreeTransfers(e.target.value)}
+                  size="small"
+                  inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
+                />
+                <Button
+                  variant="contained"
+                  onClick={handleSuggest}
+                  disabled={!selectedPlayers.length}
+                >
+                  Suggest
+                </Button>
+              </Stack>
+
+              {calc && (
+                <Box>
+                  <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                    Best Moves ({calc.suggestions.length})
+                  </Typography>
+                  {!calc.suggestions.length && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 1 }}
+                    >
+                      No beneficial transfer found within your budget and team
+                      limits.
+                    </Typography>
+                  )}
+                  <Stack spacing={1}>
+                    {calc.suggestions.map((s, i) => {
+                      const outTeam = teamsById.get(s.out.element.team);
+                      const inTeam = teamsById.get(s.in.element.team);
+                      return (
+                        <Box
+                          key={i}
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                          }}
+                        >
+                          <Typography variant="body2">
+                            Out {s.out.element.web_name} (
+                            {outTeam?.short_name ?? outTeam?.name ?? ""}) → In{" "}
+                            {s.in.element.web_name} (
+                            {inTeam?.short_name ?? inTeam?.name ?? ""})
+                          </Typography>
+                          <Stack direction="row" spacing={1}>
+                            <Chip
+                              size="small"
+                              color={s.deltaScore > 0 ? "success" : "default"}
+                              label={`+${s.deltaScore.toFixed(2)} pts`}
+                            />
+                            <Chip
+                              size="small"
+                              label={`$${(s.deltaCost / 10).toFixed(1)}m`}
+                              variant="outlined"
+                            />
+                          </Stack>
+                        </Box>
+                      );
+                    })}
+                  </Stack>
+
+                  <Box sx={{ mt: 2 }}>
+                    <Typography variant="body2">
+                      Total delta score: {calc.totalDeltaScore.toFixed(2)}
+                    </Typography>
+                    <Typography variant="body2">
+                      Used bank: ${((calc.usedBank || 0) / 10).toFixed(1)}m
+                    </Typography>
+                    <Typography variant="body2">
+                      Initial score: {calc.initialScore.toFixed(2)}
+                    </Typography>
+                    <Typography variant="body2">
+                      Final score: {calc.finalScore.toFixed(2)}
+                    </Typography>
+                  </Box>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+export default SuggestedTransfersPage;


### PR DESCRIPTION
## Suggested Transfers feature

- Adds a new page to propose optimal transfer swaps based on your selected squad, bank, and free transfers.
- Shows each player’s club (short and full name) in lists, selected squad chips, and suggested moves.
- Wired into the app nav and home grid.

### What’s included
- `src/app/transfers.ts`: Greedy same-position swap algorithm respecting bank and per-team limits; returns best moves and deltas.
- `src/modules/SuggestedTransfers.tsx`: UI to pick your 15-man squad, set bank and free transfers, and view suggested ins/outs with score and cost impact.
- `src/App.tsx`: Adds route and menu link for Suggested Transfers.
- `src/modules/Home.tsx`: Adds Suggested Transfers card to the homepage.

### How it works (brief)
- Evaluates all same-position swaps, skips duplicates, respects team limit and budget.
- Picks up to the number of free transfers with the highest score gain.
- Returns suggestions, new squad projection, and score/cost deltas.

### How to test
1. Run the app and open `/suggested-transfers`.
2. Select up to 15 players as your current squad.
3. Enter your bank (in millions) and free transfers (1–2).
4. Click “Suggest” and review the proposed outs/ins and total delta score.

### Notes / Follow-ups
- Potential enhancements:
  - Cross-position swaps with full position-limit validation.
  - Consider point hits beyond free transfers.
  - Persist selections (bank, squad) in local storage.